### PR TITLE
added missing 'pull' require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var pull = require('pull-stream')
 var pullWeird = require('./pull-weird')
 var PacketStream = require('packet-stream')
 var EventEmitter = require('events').EventEmitter


### PR DESCRIPTION
The `pull.error` call was failing without this require
