### PR TITLE
Remove callback requirement for async calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,9 @@ module.exports = function (remoteApi, localApi, serializer) {
       if(_cb) _cb(err)
     })
 
-    var noop = function(){}
+    var noop = function(err) {
+      if (err) throw err
+    }
     if(remoteApi.async)
       remoteApi.async.forEach(function (name) {
         emitter[name] = function () {


### PR DESCRIPTION
When making async-type RPC calls, there are times when I dont care about the response, so I dont provide a callback.
