### PR TITLE
add ._logging flag to enable async method RTT time logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = function (remoteApi, localApi, serializer) {
     local = local || {}
 
     var emitter = new EventEmitter ()
+    emitter._logging = false
 
     function has(type, name) {
       return type === getPath(localApi, name) && isFunction(get(name))
@@ -187,6 +188,14 @@ module.exports = function (remoteApi, localApi, serializer) {
 
             if (!ps)
               return cb(new Error('stream is closed'))
+            if (emitter._logging) {
+              var ts = Date.now()
+              var _cb = cb
+              cb = function (err, res) {
+                console.debug(name.join('.'), Date.now() - ts, 'ms')
+                _cb(err, res)
+              }
+            }
             ps.request({name: name, args: args}, cb)
           }
         : 'source' === type ?


### PR DESCRIPTION
this helps with profiling

working on phoenix, I can open the console and do `phoenix.ssb._logging = true` to see RT times for the non-stream rpc calls