### PR TITLE
Rewrite permissions system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - '0.10'
+  - '0.12'
+  - iojs
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var server = MRPC(null, api) ({
   stuff: function () {
     return pull.values([1, 2, 3, 4, 5])
   }
-}
+})
 
 var a = client.createStream()
 var b = server.createStream()
@@ -57,15 +57,31 @@ pull(a.stuff(), pull.drain(console.log))
 
 If you are exposing an api over a network connection,
 then you probably want some sort of authorization system.
-muxrpc provides some help with this, but leaves most of the trouble up to you.
+`muxrpc@4` and earlier had a `rpc.permissions()` method on
+the rpc object, but this has been removed. Now you must
+provide a permissions object, which has methods `{pre, post}`.
+`pre` is called with the path and arguments before the api
+method is actually called, and if it returns false, then the
+user gets an error and the method is not called.
 
+This is much more flexible than attaching a standard permissions
+method--now all methods on the rpc object act the same (call remote
+methods) and it's possible to have a method named "permissions"
+
+A helper module for providing permissions is provided,
+this enables you to update permissions on the fly
 ``` js
+
+var Permissions = require('muxrpc/permissions')
 
 var api = {
   foo: 'async',
   bar: 'async',
   auth: 'async'
 }
+
+//set initial settings
+var perms = Perms({allow: ['auth']})
 
 var rpc = muxrpc(null, api, serializer)({
   foo: function (val, cb) {
@@ -79,15 +95,15 @@ var rpc = muxrpc(null, api, serializer)({
     //using allow or deny lists.
 
     if(pass === 'whatever')
-      this.permissions({deny: ['bar']}) //allow everything except "bar"
+      perms({deny: ['bar']}) //allow everything except "bar"
     else if(pass === 's3cr3tz')
-      this.permissions({}) //allow everything!!!
+      perms({}) //allow everything!!!
     else return cb(new Error('ACCESS DENIED'))
 
     //else we ARE authorized.
     cb(null, 'ACCESS GRANTED')
   }
-}).permissions({allow: ['auth']})
+})
 
 //Get a stream to connect to the remote. As in the above example!
 var ss = rpc.createStream()

--- a/index.js
+++ b/index.js
@@ -29,6 +29,15 @@ function getPath(obj, path) {
   return obj
 }
 
+function isPerms (p) {
+  return (
+    p &&
+    isFunction(p.pre) &&
+    isFunction(p.test) &&
+    isFunction(p.post)
+  )
+}
+
 var abortSink = pull.Sink(function (read) { read(true, function () {}) })
 
 module.exports = function (remoteApi, localApi, codec) {
@@ -36,14 +45,18 @@ module.exports = function (remoteApi, localApi, codec) {
   remoteApi = remoteApi || {}
 
   if(!codec) codec = PSC
-  
+
   //pass the manifest to the permissions so that it can know
   //what something should be.
-  var perms = Permissions(localApi)
 
-  return function (local) {
+  return function (local, perms) {
     local = local || {}
 
+    if(isPerms(perms));
+    else if(isObject(perms))
+      perms = Permissions(perms)
+    else
+      perms = Permissions()
     var emitter = new EventEmitter ()
 
     function has(type, name) {
@@ -288,8 +301,6 @@ module.exports = function (remoteApi, localApi, codec) {
       stream.close = ps.close.bind(ps)
       return stream
     }
-
-    emitter.permissions = perms
 
     emitter.closed = false
     emitter.close = function (cb) {

--- a/permissions.js
+++ b/permissions.js
@@ -46,34 +46,36 @@ create perms:
   }
 */
 
-module.exports = function () {
-  var whitelist = null
-  var blacklist = {}
+module.exports = function (opts) {
+  var allow = null
+  var deny = {}
 
   function perms (opts) {
     if(opts.allow) {
-      whitelist = {}
+      allow = {}
       opts.allow.forEach(function (path) {
-        u.set(whitelist, toArray(path), true)
+        u.set(allow, toArray(path), true)
       })
     }
-    else whitelist = null
+    else allow = null
 
     if(opts.deny)
       opts.deny.forEach(function (path) {
-        u.set(blacklist, toArray(path), true)
+        u.set(deny, toArray(path), true)
       })
-    else blacklist = {}
+    else deny = {}
 
     return this
   }
 
+  if(opts) perms(opts)
+
   perms.pre = function (name, args) {
     name = isArray(name) ? name : [name]
-    if(whitelist && !u.prefix(whitelist, name))
+    if(allow && !u.prefix(allow, name))
       return new Error('method:'+name + ' is not on whitelist')
 
-    if(blacklist && u.prefix(blacklist, name))
+    if(deny && u.prefix(deny, name))
       return new Error('method:'+name + ' is on blacklist')
   }
 
@@ -83,6 +85,10 @@ module.exports = function () {
 
   perms.test = function (name, args) {
     return perms.pre(name, args)
+  }
+
+  perms.get = function () {
+    return {allow: allow, deny: deny}
   }
 
   return perms

--- a/test/async.js
+++ b/test/async.js
@@ -9,7 +9,9 @@ module.exports = function(serializer, buffers) {
   ? function (b) {
     return (
         Buffer.isBuffer(b)
-      ? {type: 'Buffer', data: [].slice.call(b) }
+        //reserialize, to take into the account
+        //changes Buffer#toJSON between 0.10 and 0.12
+      ? JSON.parse(JSON.stringify(b))
       : b
     )
   }

--- a/test/initial-perms.js
+++ b/test/initial-perms.js
@@ -1,0 +1,102 @@
+var tape = require('tape')
+var pull = require('pull-stream')
+var pushable = require('pull-pushable')
+var mux = require('../')
+var cont = require('cont')
+
+var api = {
+  get    : 'async',
+  put    : 'async',
+  del    : 'async',
+  read   : 'source',
+  nested: {
+    get    : 'async',
+    put    : 'async',
+    del    : 'async',
+    read   : 'source',
+  }
+}
+
+function id (e) {
+  return e
+}
+
+var store = {
+  foo: 1,
+  bar: 2,
+  baz: 3
+}
+
+function createServerAPI (store) {
+  var rpc
+  var name = 'nobody'
+
+  //this wraps a session.
+
+  var session = {
+    whoami: function (cb) {
+      cb(null, {okay: true, user: name})
+    },
+    get: function (key, cb) {
+      return cb(null, store[key])
+    },
+    put: function (key, value, cb) {
+      store[key] = value
+      cb()
+    },
+    del: function (key, cb) {
+      delete store[key]
+      cb()
+    },
+    read: function () {
+      return pull.values([1,2,3])
+    }
+  }
+
+  session.nested = session
+
+  return rpc = mux(null, api, id)(session, {allow: ['get']})
+}
+
+function createClientAPI() {
+  return mux(api, null, id)()
+}
+
+tape('secure rpc', function (t) {
+
+  var server = createServerAPI(store)
+  var client = createClientAPI()
+
+  var ss = server.createStream()
+  var cs = client.createStream()
+
+  pull(cs, ss, cs)
+
+  cont.para([
+    function (cb) {
+      client.get('foo', function (err) {
+        t.notOk(err); cb()
+      })
+    },
+    function (cb) {
+      client.put('foo', function (err) {
+        t.ok(err); cb()
+      })
+    },
+    function (cb) {
+      client.del('foo', function (err) {
+        t.ok(err); cb()
+      })
+    },
+    function (cb) {
+      pull(client.read(), pull.collect(function (err) {
+        t.ok(err); cb()
+      }))
+    }
+  ])(function (err) {
+    t.end()
+  })
+
+})
+
+


### PR DESCRIPTION
this removes the permissions method from the rpc object.
instead a permissions object must be passed into rpc factory.

This design is much more flexible, you can now have a method named `permissions`,
and you can use any permissions system that has the right interface.

And also, this means that all the methods on the rpc object act the same way (call a remote method)

(My immediate motivation for this is to enable a method to query your curret permissions on sbot)