### PR TITLE
Destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,9 +303,12 @@ module.exports = function (remoteApi, localApi, codec) {
     }
 
     emitter.closed = false
-    emitter.close = function (cb) {
-      if (!ps)
-        return (cb && cb())
+    emitter.close = function (err, cb) {
+      if(isFunction(err))
+        cb = err, err = false
+      if (!ps) return (cb && cb())
+      if(err) return ps.destroy(err), (cb && cb())
+
       ps.close(function (err) {
         if(!emitter.closed) {
           emitter.closed = true


### PR DESCRIPTION
allows closing a rpc channel immediately, without waiting for streams to finish.