### PR TITLE
permissions can be function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,14 @@ The manifest is simply an object mapping to strings, or nested objects.
 If you are exposing an api over a network connection,
 then you probably want some sort of authorization system.
 `muxrpc@4` and earlier had a `rpc.permissions()` method on
-the rpc object, but this has been removed. Now you must
-provide a permissions object, which has methods `{pre, post}`.
-`pre` is called with the path and arguments before the api
-method is actually called, and if it returns false, then the
-user gets an error and the method is not called.
+the rpc object, but this has been removed.
+Now you must pass a permissions function, which is called with
+the `name` (a path) and `args`, if this function does not throw
+an error, then the call is allowed.
 
-This is much more flexible than attaching a standard permissions
-method--now all methods on the rpc object act the same (call remote
-methods) and it's possible to have a method named "permissions"
+In some cases, a simple allow/deny list is sufficient.
+A helper function, is provided, which was a part of muxrpc@4
 
-A helper module for providing permissions is provided,
-this enables you to update permissions on the fly
 ``` js
 
 var Permissions = require('muxrpc/permissions')
@@ -129,7 +125,7 @@ var rpc = muxrpc(null, api, serializer)({
     //else we ARE authorized.
     cb(null, 'ACCESS GRANTED')
   }
-})
+}, perms)
 
 //Get a stream to connect to the remote. As in the above example!
 var ss = rpc.createStream()
@@ -141,3 +137,6 @@ var ss = rpc.createStream()
 ## License
 
 MIT
+
+
+

--- a/local-api.js
+++ b/local-api.js
@@ -32,7 +32,7 @@ function createLocalCall(local, localApi, perms) {
   }
 
   return function (type, name, args) {
-    var err = perms.pre(name)
+    var err = perms.pre(name, args)
     if(err) throw err
     return localCall.call(this, type, name, args)
   }

--- a/local-api.js
+++ b/local-api.js
@@ -5,7 +5,7 @@ var u            = require('./util')
 module.exports = 
 
 function createLocalCall(local, localApi, perms) {
-  perms = Permissions(perms)
+  var test = Permissions(perms).pre
 
   function has(type, name) {
     return type === u.get(localApi, name)
@@ -37,4 +37,5 @@ function createLocalCall(local, localApi, perms) {
     return localCall.call(this, type, name, args)
   }
 }
+
 

--- a/permissions.js
+++ b/permissions.js
@@ -57,8 +57,8 @@ create perms:
 */
 
 module.exports = function (opts) {
+  if(isFunction(opts)) return {pre: opts}
   if(isPerms(opts)) return opts
-
   var allow = null
   var deny = {}
 
@@ -95,6 +95,7 @@ module.exports = function (opts) {
     //TODO
   }
 
+  //alias for pre, used in tests.
   perms.test = function (name, args) {
     return perms.pre(name, args)
   }
@@ -105,3 +106,4 @@ module.exports = function (opts) {
 
   return perms
 }
+

--- a/stream.js
+++ b/stream.js
@@ -30,9 +30,9 @@ module.exports = function initStream (localCall, codec, onClose) {
 
   var ps = PacketStream({
     message: function (msg) {
-      if(isString(msg)) return
-      if(msg.length > 0 && isString(msg[0]))
-        localCall('msg', 'emit', msg)
+//      if(isString(msg)) return
+//      if(msg.length > 0 && isString(msg[0]))
+//        localCall('msg', 'emit', msg)
     },
     request: function (opts, cb) {
       var name = opts.name, args = opts.args

--- a/test/missing.js
+++ b/test/missing.js
@@ -1,0 +1,63 @@
+var pull = require('pull-stream')
+var mux = require('../')
+var tape = require('tape')
+var Pushable = require('pull-pushable')
+
+function delay(fun) {
+  return function (a, b) {
+    setImmediate(function () {
+      fun(a, b)
+    })
+  }
+}
+
+
+var client = {
+  echo   : 'duplex',
+}
+
+module.exports = function (codec) {
+
+tape('close after both sides of a duplex stream ends', function (t) {
+
+  var A = mux(client, null, codec) ()
+  var B = mux(null, client, codec) ({
+  })
+
+  var bs = B.createStream()
+  var as = A.createStream()
+
+  var source = Pushable()
+
+  pull(
+    function (err, cb) {
+      if(!err) setTimeout(function () { cb(null, Date.now()) })
+      else console.log('ERROR', err)
+    },
+    A.echo(function (err) {
+      console.error('caught err')
+    }),
+    pull.collect(function (err, ary) {
+      t.ok(err)
+      t.end()
+    })
+  )
+
+  pull(as, bs, as)
+
+})
+
+//TODO: write test for when it's a duplex api that
+//is missing on the remote!!!
+
+}
+
+if(!module.parent) module.exports(function (e) { return e })
+
+
+
+
+
+
+
+


### PR DESCRIPTION
I had a side project that actually needed to use permissions on arguments within a call, so an allow/deny list isn't sufficient. There where several wonky things in permissions code, such as it would take a permissions object that wasn't just a list, but only if it defined `{pre, post, test}` functions, even though only `{pre}` was ever called.

This now supports passing a function in as permissions object.

This change is backwards compatible.

The other thing that we've moved away from but is still present in this code is the idea of making a connection and then authorizing - i.e. changing permissions level within a session. It's much simpler, (whether over shs or http, to authorize at the connection level)
