### PR TITLE
Bootstrap manifest in client if none was given

### DIFF
--- a/api.js
+++ b/api.js
@@ -15,7 +15,7 @@ function noop (err) {
   if (err) throw explain(err, 'callback not provided')
 }
 
-module.exports = function (path, remoteApi, bootstrap, _remoteCall) {
+module.exports = function (path, remoteApi, _remoteCall, bootstrap) {
 
   var emitter = new EventEmitter()
 

--- a/api.js
+++ b/api.js
@@ -43,24 +43,17 @@ module.exports = function (path, remoteApi, _remoteCall, bootstrap) {
     return obj
   }
 
-  emitter.bootstrap = function (cb) {
-    if (!cb)
-      cb = noop
-
-    if (bootstrap) {
-      remoteCall('async', 'manifest', [function (err, remote) {
-        if(err)
-          return cb(err)
-        recurse(emitter, remote, path)
-        cb(null, remote)
-      }])
-    }
-  }
-
   if (bootstrap) {
     remoteApi['manifest'] = function () {
       return remoteCall('async', 'manifest', [].slice.call(arguments))
     }
+
+    remoteCall('async', 'manifest', [function (err, remote) {
+      if(err)
+        return bootstrap(err)
+      recurse(emitter, remote, path)
+      bootstrap(null, remote)
+    }])
   } else {
     recurse(emitter, remoteApi, path)
   }

--- a/api.js
+++ b/api.js
@@ -52,7 +52,7 @@ module.exports = function (path, remoteApi, _remoteCall, bootstrap) {
       if(err)
         return bootstrap(err)
       recurse(emitter, remote, path)
-      bootstrap(null, remote)
+      bootstrap(null, emitter)
     }])
   } else {
     recurse(emitter, remoteApi, path)

--- a/api.js
+++ b/api.js
@@ -52,7 +52,7 @@ module.exports = function (path, remoteApi, _remoteCall, bootstrap) {
       if(err)
         return bootstrap(err)
       recurse(emitter, remote, path)
-      bootstrap(null, emitter)
+      bootstrap(null, remote, emitter)
     }])
   } else {
     recurse(emitter, remoteApi, path)

--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ function createMuxrpc (remoteApi, localApi, local, id, perms, codec, legacy) {
     }
   )
 
-  emitter = createApi([], remoteApi, bootstrap, function (type, name, args, cb) {
+  emitter = createApi([], remoteApi, function (type, name, args, cb) {
     if(ws.closed) throw new Error('stream is closed')
     return ws.remoteCall(type, name, args, cb)
-  })
+  }, bootstrap)
 
   if(legacy) {
     Object.__defineGetter__.call(emitter, 'id', function () {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ var createApi    = require('./api')
 var createLocalCall = require('./local-api')
 
 function createMuxrpc (remoteApi, localApi, local, id, perms, codec, legacy) {
+  var bootstrap
+  if (!localApi && !remoteApi) {
+    bootstrap = true
+  }
+
   localApi = localApi || {}
   remoteApi = remoteApi || {}
   var emitter
@@ -13,7 +18,6 @@ function createMuxrpc (remoteApi, localApi, local, id, perms, codec, legacy) {
 
   //pass the manifest to the permissions so that it can know
   //what something should be.
-
   var _cb, ws
   var context = {
       _emit: function (event, value) {
@@ -35,7 +39,7 @@ function createMuxrpc (remoteApi, localApi, local, id, perms, codec, legacy) {
     }
   )
 
-  emitter = createApi([], remoteApi, function (type, name, args, cb) {
+  emitter = createApi([], remoteApi, bootstrap, function (type, name, args, cb) {
     if(ws.closed) throw new Error('stream is closed')
     return ws.remoteCall(type, name, args, cb)
   })
@@ -71,7 +75,6 @@ function createMuxrpc (remoteApi, localApi, local, id, perms, codec, legacy) {
   }
 
   return emitter
-
 }
 
 module.exports = function (remoteApi, localApi, codec) {
@@ -81,4 +84,3 @@ module.exports = function (remoteApi, localApi, codec) {
     return createMuxrpc(remoteApi, localApi, local, id, perms, codec, true)
   }
 }
-

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ var createLocalCall = require('./local-api')
 
 function createMuxrpc (remoteApi, localApi, local, id, perms, codec, legacy) {
   var bootstrap
-  if (!localApi && !remoteApi) {
-    bootstrap = true
+  if ('function' === typeof remoteApi) {
+    bootstrap = remoteApi
+    remoteApi = {}
   }
 
   localApi = localApi || {}

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,0 +1,38 @@
+var pull = require('pull-stream')
+var tape = require('tape')
+var Muxrpc = require('../')
+
+var manifest = { hello: 'sync', manifest: 'sync' }
+var api = {
+  hello: function (n) {
+    if(this._emit) this._emit('hello', n)
+    console.log('hello from ' + this.id)
+    return n + ':' + this.id
+  },
+  manifest: function () {
+    return manifest
+  }
+}
+
+tape('emit an event from the called api function', async function (t) {
+
+  t.plan(3)
+
+  var bob = Muxrpc(null, manifest)  (api)
+  var alice = Muxrpc() ()
+  var as = alice.createStream()
+  pull(as, bob.createStream(), as)
+  alice.bootstrap(() => {})
+
+  bob.id = 'Alice'
+
+  bob.on('hello', function (n) {
+    console.log('HELLO')
+    t.equal(n, 'bob')
+  })
+  alice.hello('bob', function (err, data) {
+    t.notOk(err)
+    t.equal(data, 'bob:Alice')
+    t.end()
+  })
+})

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -16,11 +16,13 @@ var api = {
 
 tape('emit an event from the called api function', async function (t) {
 
-  t.plan(4)
+  t.plan(6)
 
   var bob = Muxrpc(null, manifest)  (api)
-  var cb = function (err, val) {
+  var cb = function (err, val, emitter) {
     t.notOk(err)
+    t.deepEqual(manifest, val)
+    t.ok(emitter)
   }
 
   var alice = Muxrpc(cb) ()

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -16,13 +16,17 @@ var api = {
 
 tape('emit an event from the called api function', async function (t) {
 
-  t.plan(3)
+  t.plan(5)
 
   var bob = Muxrpc(null, manifest)  (api)
-  var alice = Muxrpc() ()
+  var cb = function (err, val) {
+    t.notOk(err)
+    t.deepEqual(manifest, val)
+  }
+
+  var alice = Muxrpc(cb) ()
   var as = alice.createStream()
   pull(as, bob.createStream(), as)
-  alice.bootstrap(() => {})
 
   bob.id = 'Alice'
 

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -16,12 +16,11 @@ var api = {
 
 tape('emit an event from the called api function', async function (t) {
 
-  t.plan(5)
+  t.plan(4)
 
   var bob = Muxrpc(null, manifest)  (api)
   var cb = function (err, val) {
     t.notOk(err)
-    t.deepEqual(manifest, val)
   }
 
   var alice = Muxrpc(cb) ()

--- a/test/initial-perms-bootstrap.js
+++ b/test/initial-perms-bootstrap.js
@@ -62,21 +62,15 @@ function createServerAPI (store) {
   return rpc = mux(null, api, id)(session, {allow: ['manifest', 'get']})
 }
 
-function createClientAPI() {
-  return mux(null, null, id)()
+function noop () {}
+
+function createClientAPI(cb) {
+  return mux(cb, null, id)()
 }
 
 tape('secure rpc', async function (t) {
 
-  var server = createServerAPI(store)
-  var client = createClientAPI()
-
-  var ss = server.createStream()
-  var cs = client.createStream()
-
-  pull(cs, ss, cs)
-
-  client.bootstrap(() => {
+  var afterBootstrap = function () {
     cont.para([
       function (cb) {
         client.get('foo', function (err) {
@@ -101,5 +95,13 @@ tape('secure rpc', async function (t) {
     ])(function (err) {
       t.end()
     })
-  })
+  }
+
+  var server = createServerAPI(store)
+  var client = createClientAPI(afterBootstrap)
+
+  var ss = server.createStream()
+  var cs = client.createStream()
+
+  pull(cs, ss, cs)
 })

--- a/test/initial-perms-bootstrap.js
+++ b/test/initial-perms-bootstrap.js
@@ -1,0 +1,105 @@
+var tape = require('tape')
+var pull = require('pull-stream')
+var pushable = require('pull-pushable')
+var mux = require('../')
+var cont = require('cont')
+
+var api = {
+  get    : 'async',
+  put    : 'async',
+  del    : 'async',
+  read   : 'source',
+  nested: {
+    get    : 'async',
+    put    : 'async',
+    del    : 'async',
+    read   : 'source',
+  },
+  manifest: 'sync'
+}
+
+function id (e) {
+  return e
+}
+
+var store = {
+  foo: 1,
+  bar: 2,
+  baz: 3
+}
+
+function createServerAPI (store) {
+  var rpc
+  var name = 'nobody'
+
+  //this wraps a session.
+
+  var session = {
+    whoami: function (cb) {
+      cb(null, {okay: true, user: name})
+    },
+    get: function (key, cb) {
+      return cb(null, store[key])
+    },
+    put: function (key, value, cb) {
+      store[key] = value
+      cb()
+    },
+    del: function (key, cb) {
+      delete store[key]
+      cb()
+    },
+    read: function () {
+      return pull.values([1,2,3])
+    },
+    manifest: function () {
+      return api
+    }
+  }
+
+  session.nested = session
+
+  return rpc = mux(null, api, id)(session, {allow: ['manifest', 'get']})
+}
+
+function createClientAPI() {
+  return mux(null, null, id)()
+}
+
+tape('secure rpc', async function (t) {
+
+  var server = createServerAPI(store)
+  var client = createClientAPI()
+
+  var ss = server.createStream()
+  var cs = client.createStream()
+
+  pull(cs, ss, cs)
+
+  client.bootstrap(() => {
+    cont.para([
+      function (cb) {
+        client.get('foo', function (err) {
+          t.notOk(err); cb()
+        })
+      },
+      function (cb) {
+        client.put('foo', function (err) {
+          t.ok(err); cb()
+        })
+      },
+      function (cb) {
+        client.del('foo', function (err) {
+          t.ok(err); cb()
+        })
+      },
+      function (cb) {
+        pull(client.read(), pull.collect(function (err) {
+          t.ok(err); cb()
+        }))
+      }
+    ])(function (err) {
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Add functionality to call a manifest method on the server in order to
bootstrap the manifest. This pre-supposes that the server has a manifest
method, so those using this functionality should ensure that is the
case, as a convention.