### PR TITLE
documentation drive: document api, remove documentation for broken things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 4
-  - '0.12'
+  - 8
+  - 10
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ var api = {
     return pull.values([1, 2, 3, 4, 5])
   }
 }
+
 //pass the manifests into the constructor, and then pass the local api object you are wrapping
 //(if there is a local api)
 var client = MRPC(manifest, null) () //MRPC (remoteManifest, localManifest) (localApi)
@@ -174,9 +175,36 @@ var ss = rpc.createStream()
 
 ```
 
+## bootstrapping - automatically loading the remote manifest.
+
+sometimes you don't know the remote manifest yet. if you pass a callback
+instead of `remoteApi` a an async method `manifest` is called on the remote
+which should return a manifest. This then used as the remote manifest
+and the callback is called.
+
+``` js
+
+var manifest = { hello: 'sync', manifest: 'sync' }
+
+var bob = Muxrpc(null, manifest)  ({
+  hello: function (n) {
+    if(this._emit) this._emit('hello', n)
+    console.log('hello from ' + this.id)
+    return n + ':' + this.id
+  },
+  manifest: function () {
+    return manifest
+  }
+})
+
+var alice = Muxrpc(function (err, alice) {
+  //alice now knows the bob's api
+})
+var as = alice.createStream()
+pull(as, bob.createStream(), as)
+```
 
 ## License
 
 MIT
-
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ var api = {
     return pull.values([1, 2, 3, 4, 5])
   }
 }
-
 //pass the manifests into the constructor, and then pass the local api object you are wrapping
 //(if there is a local api)
 var client = MRPC(manifest, null) () //MRPC (remoteManifest, localManifest) (localApi)
@@ -175,36 +174,9 @@ var ss = rpc.createStream()
 
 ```
 
-## bootstrapping - automatically loading the remote manifest.
-
-sometimes you don't know the remote manifest yet. if you pass a callback
-instead of `remoteApi` a an async method `manifest` is called on the remote
-which should return a manifest. This then used as the remote manifest
-and the callback is called.
-
-``` js
-
-var manifest = { hello: 'sync', manifest: 'sync' }
-
-var bob = Muxrpc(null, manifest)  ({
-  hello: function (n) {
-    if(this._emit) this._emit('hello', n)
-    console.log('hello from ' + this.id)
-    return n + ':' + this.id
-  },
-  manifest: function () {
-    return manifest
-  }
-})
-
-var alice = Muxrpc(function (err, alice) {
-  //alice now knows the bob's api
-})
-var as = alice.createStream()
-pull(as, bob.createStream(), as)
-```
 
 ## License
 
 MIT
+
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ var MRPC = require('muxrpc')
 var pull = require('pull-stream')
 
 //we need a manifest of methods we wish to expose.
-var api = {
+var manifest = {
   //async is a normal async function
   hello: 'async',
 
@@ -23,25 +23,41 @@ var api = {
   //TODO: sink and duplex pull-streams
 }
 
-//pass the api into the constructor, and then pass the object you are wrapping
-//(if there is a local api)
-var client = MRPC(api, null) () //remoteApi, localApi
-var server = MRPC(null, api) ({
+//the actual methods which the server exposes
+var api = {
   hello: function (name, cb) {
     cb(null, 'hello, ' + name + '!')
   },
   stuff: function () {
     return pull.values([1, 2, 3, 4, 5])
   }
-})
+}
 
-// pass in a cb for the stream end event
-var a = client.createStream(console.log.bind(console, 'stream is closed'))
-var b = server.createStream()
-// or subscribe to the 'closed' event
-b.once('closed', console.log.bind(console, 'stream is closed'))
+//pass the manifests into the constructor, and then pass the local api object you are wrapping
+//(if there is a local api)
+var client = MRPC(manifest, null) () //MRPC (remoteManifest, localManifest) (localApi)
+var server = MRPC(null, manifest) (api)
+```
+now set up a server, and connect to it...
+```
+var net = require('net')
 
-pull(a, b, a) //pipe together
+net.createServer(function (stream) {
+  stream = toPull.duplex(stream) //turn into a pull-stream
+  //connect the output of the net stream to the muxrpc stream
+  //and then output of the muxrpc stream to the net stream
+  pull(stream, server.createStream(), stream)
+}).listen(8080)
+//connect a pair of duplex streams together.
+
+var stream = toPull.duplex(net.connect(8080))
+pull(stream, client.createStream(onClose), stream)
+
+function onClose () {
+  console.log('connected to muxrpc server')
+}
+
+//now you can call methods like this.
 
 client.hello('world', function (err, value) {
   if(err) throw err
@@ -57,13 +73,45 @@ pull(client.stuff(), pull.drain(console.log))
 // 5
 ```
 
+## Api: createMuxrpc (remoteManifest, localManifest, localApi, id, perms, codec, legacy) => rpc
+
+`remoteManifest` the manifest expected on the remote end of this connection.
+`localManifest` the manifest of the methods we are exposing locally.
+`localApi` the actual methods we are exposing - this is on object with function with call types
+that match the manifest.
+
+`id` a string identifing the _remote_ identity. `muxrpc` only knows the name of it's friend
+but not it's own name.
+
+`perms` a permissions object with `{test: function (path, type, args) {} }` function.
+
+`codec` stream encoding. defaults to [packet-stream-codec](https://github.com/ssbc/packet-stream-codec)
+
+`legacy` engage legacy mode.
+
+### rpc
+
+an [EventEmitter](https://devdocs.io/node/events#events_class_eventemitter)
+containing proxies for all the methods defined in your manifest, as well as the following:
+
+* `stream`
+* `createStream` method, **only if `legacy` mode**
+* `id` (string, the id of the remote)
+* `_emit` emit an event locally.
+* `closed` a boolean, wether the instance is closed.
+* `close` an async method to close this connection, will end the `rpc.stream`
+
+And every method provided in the manifest. If a method in the manifest has the same
+name as a built in, the built in will override the manifest, and you will not be able
+to call that remove method.
+
 ## Manifest
 
-like multilevel, a [manifest is required](https://github.com/juliangruber/multilevel#plugins)
-except it works a little differently, and since muxrpc works with any api,
-not assuming leveldb then you must write the manifest yourself.
-
-The manifest is simply an object mapping to strings, or nested objects.
+`muxrpc` works with async functions, sync functions, and pull-streams.
+But that javascript is dynamic, we need to tell muxrpc what sort of method
+should be at what api, that is what the "mainfest" is for.
+The manifest is simply an object mapping a key to one of the strings "sync" "async" "source" "sink" or "duplex",
+or a nested manifest.
 
 ``` js
 {
@@ -84,22 +132,14 @@ The manifest is simply an object mapping to strings, or nested objects.
 
 ## Permissions
 
-If you are exposing an api over a network connection,
-then you probably want some sort of authorization system.
-`muxrpc@4` and earlier had a `rpc.permissions()` method on
-the rpc object, but this has been removed.
-Now you must pass a permissions function, which is called with
-the `name` (a path) and `args`, if this function does not throw
-an error, then the call is allowed.
-
-In some cases, a simple allow/deny list is sufficient.
-A helper function, is provided, which was a part of muxrpc@4
+muxrpc includes a helper module for defining permissions.
+it implements a simlpe allow/deny list to define permissions for a given connection.
 
 ``` js
 
 var Permissions = require('muxrpc/permissions')
 
-var api = {
+var manifest = {
   foo: 'async',
   bar: 'async',
   auth: 'async'
@@ -108,7 +148,7 @@ var api = {
 //set initial settings
 var perms = Perms({allow: ['auth']})
 
-var rpc = muxrpc(null, api, serializer)({
+var rpc = muxrpc(null /* no remote manifest */, manifest, serializer)({
   foo: function (val, cb) {
     cb(null, {okay: 'foo'})
   },
@@ -128,14 +168,14 @@ var rpc = muxrpc(null, api, serializer)({
     //else we ARE authorized.
     cb(null, 'ACCESS GRANTED')
   }
-}, perms)
+}, perms) //pass the perms object to the second argument of the constructor.
 
 //Get a stream to connect to the remote. As in the above example!
 var ss = rpc.createStream()
 
 ```
 
-## bootstrapping
+## bootstrapping - automatically loading the remote manifest.
 
 sometimes you don't know the remote manifest yet. if you pass a callback
 instead of `remoteApi` a an async method `manifest` is called on the remote
@@ -167,8 +207,4 @@ pull(as, bob.createStream(), as)
 ## License
 
 MIT
-
-
-
-
 

--- a/local-api.js
+++ b/local-api.js
@@ -5,7 +5,6 @@ var u            = require('./util')
 module.exports = 
 
 function createLocalCall(api, manifest, perms) {
-//  if(!perms) throw new Error('perms is not defined')
   perms = Permissions(perms)
 
   function has(type, name) {
@@ -38,6 +37,4 @@ function createLocalCall(api, manifest, perms) {
     return localCall.call(this, type, name, args)
   }
 }
-
-
 

--- a/local-api.js
+++ b/local-api.js
@@ -5,6 +5,7 @@ var u            = require('./util')
 module.exports = 
 
 function createLocalCall(api, manifest, perms) {
+//  if(!perms) throw new Error('perms is not defined')
   perms = Permissions(perms)
 
   function has(type, name) {
@@ -37,4 +38,6 @@ function createLocalCall(api, manifest, perms) {
     return localCall.call(this, type, name, args)
   }
 }
+
+
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tape": "~3.0.0"
   },
   "scripts": {
-    "prepublish": "npm ls && npm test",
+    "prepublishOnly": "npm ls && npm test",
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",


### PR DESCRIPTION
documents the (non-legacy) api and I realized that bootstrapping was totally broken. I'm not sure how that happened, I suspect a weird merge? I did notice there were tests for it at one point, no one has complained about this, so I recommend we just remove that feature.

The documentation was mostly focused around examples before, which is pretty good, but now there is a listing of the actual apis and methods.